### PR TITLE
Fix problem with importing Google proto

### DIFF
--- a/protobuf.go
+++ b/protobuf.go
@@ -1,14 +1,16 @@
 package protobuf
 
 import (
+	"log"
+
 	"github.com/jhump/protoreflect/desc/protoparse"
 	"google.golang.org/protobuf/encoding/protojson"
-	"log"
 
 	"go.k6.io/k6/js/modules"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
@@ -35,7 +37,7 @@ func (p *Protobuf) Load(protoFilePath, lookupType string) ProtoFile {
 	// Convert the *desc.FileDescriptor to *descriptorpb.FileDescriptorProto
 	schema := fileDesc[0].AsFileDescriptorProto()
 	// Convert the FileDescriptorProto to a protoreflect.FileDescriptor
-	fd, err := protodesc.NewFile(schema, nil)
+	fd, err := protodesc.NewFile(schema, protoregistry.GlobalFiles)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I noticed that when you do import like `import "google/protobuf/timestamp.proto";` k6 returns error:
```
proto: could not resolve import "google/protobuf/timestamp.proto": not found
```
This PR is fixing mentioned problem.