### PR TITLE
Add import path support and fix binary encoding for k6/JavaScript interop

### DIFF
--- a/protobuf.go
+++ b/protobuf.go
@@ -3,6 +3,7 @@ package protobuf
 import (
 	"context"
 	"log"
+	"path/filepath"
 
 	"github.com/bufbuild/protocompile"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -26,7 +27,7 @@ type ProtoFile struct {
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
 	// Default import paths if none provided
     if len(importPaths) == 0 {
-        importPaths = []string{".", "proto", "k6-scripts/proto"}
+        importPaths = []string{filepath.Dir(protoFile)}
     }
 	
 	compiler := protocompile.Compiler{

--- a/protobuf.go
+++ b/protobuf.go
@@ -6,9 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/bufbuild/protocompile"
-	"google.golang.org/protobuf/encoding/protojson"
-
 	"go.k6.io/k6/js/modules"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
@@ -24,85 +23,91 @@ type ProtoFile struct {
 	messageDesc protoreflect.MessageDescriptor
 }
 
+// Load compiles a proto file and returns a ProtoFile for encoding/decoding messages
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
-    // Default import paths if none provided
-    if len(importPaths) == 0 {
-        protoDir := filepath.Dir(protoFilePath)
-        absProtoDir, _ := filepath.Abs(protoDir)
-        importPaths = []string{absProtoDir}
-    }
-    
-    compiler := protocompile.Compiler{
-        Resolver: &protocompile.SourceResolver{
-            ImportPaths: importPaths,
-        },
-    }
-    
-    // Make proto file path relative to import path for protocompile
-    absProtoFile, _ := filepath.Abs(protoFilePath)
-    relPath, _ := filepath.Rel(importPaths[0], absProtoFile)
+	// Default import paths if none provided
+	if len(importPaths) == 0 {
+		protoDir := filepath.Dir(protoFilePath)
+		absProtoDir, err := filepath.Abs(protoDir)
+		if err != nil {
+			absProtoDir = protoDir
+		}
+		importPaths = []string{absProtoDir}
+	}
 
-    files, err := compiler.Compile(context.Background(), relPath)
-    if err != nil {
-        log.Fatal(err)
-    }
-    if files == nil || len(files) == 0 {
-        log.Fatal("No files were compiled")
-    }
+	compiler := protocompile.Compiler{
+		Resolver: &protocompile.SourceResolver{
+			ImportPaths: importPaths,
+		},
+	}
 
-    // Extract simple name from fully qualified name (e.g., "infra.iot_comms_poc.Ping" -> "Ping")
-    simpleName := lookupType
-    if lastDot := len(lookupType) - 1; lastDot >= 0 {
-        for i := lastDot; i >= 0; i-- {
-            if lookupType[i] == '.' {
-                simpleName = lookupType[i+1:]
-                break
-            }
-        }
-    }
+	// Make proto file path relative to import path for protocompile
+	absProtoFile, err := filepath.Abs(protoFilePath)
+	if err == nil {
+		relPath, err := filepath.Rel(importPaths[0], absProtoFile)
+		if err == nil {
+			protoFilePath = relPath
+		}
+	}
 
-    msgDesc := files[0].Messages().ByName(protoreflect.Name(simpleName))
-    if msgDesc == nil {
-        log.Fatalf("Message type %s not found", lookupType)
-    }
+	files, err := compiler.Compile(context.Background(), protoFilePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if files == nil || len(files) == 0 {
+		log.Fatal("No files were compiled")
+	}
 
-    return ProtoFile{msgDesc}
+	// Extract simple name from fully qualified name (e.g., "infra.iot_comms_poc.Ping" -> "Ping")
+	simpleName := lookupType
+	for i := len(lookupType) - 1; i >= 0; i-- {
+		if lookupType[i] == '.' {
+			simpleName = lookupType[i+1:]
+			break
+		}
+	}
+
+	msgDesc := files[0].Messages().ByName(protoreflect.Name(simpleName))
+	if msgDesc == nil {
+		log.Fatalf("Message type %s not found", lookupType)
+	}
+
+	return ProtoFile{msgDesc}
 }
 
+// Encode converts JSON string to protobuf binary format
+// Returns as Go string (binary safe) for compatibility with xk6-nats
 func (p *ProtoFile) Encode(jsonString string) string {
-    msg := dynamicpb.NewMessage(p.messageDesc)
-    err := protojson.Unmarshal([]byte(jsonString), msg)
-    if err != nil {
-        log.Printf("ERROR: protojson.Unmarshal failed: %v", err)
-        panic(err)
-    }
-    
-    data, err := proto.Marshal(msg)
-    if err != nil {
-        panic(err)
-    }
-    
-    // Return as Go string (binary safe in Go, preserves all bytes 0-255)
-    return string(data)
+	msg := dynamicpb.NewMessage(p.messageDesc)
+	
+	err := protojson.Unmarshal([]byte(jsonString), msg)
+	if err != nil {
+		log.Printf("ERROR: protojson.Unmarshal failed: %v", err)
+		panic(err)
+	}
+
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+
+	// Return as string to avoid UTF-8 corruption when passing to xk6-nats
+	return string(data)
 }
 
+// Decode converts protobuf binary format to JSON string
 func (p *ProtoFile) Decode(decodedBytes []byte) string {
-
-	decodedMessage := dynamicpb.NewMessage(p.messageDesc)
-
-	err := proto.Unmarshal(decodedBytes, decodedMessage)
+	msg := dynamicpb.NewMessage(p.messageDesc)
+	
+	err := proto.Unmarshal(decodedBytes, msg)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
-	marshalOptions := protojson.MarshalOptions{
-		UseProtoNames: true,
-	}
-
-	jsonString, err := marshalOptions.Marshal(decodedMessage)
+	jsonBytes, err := protojson.Marshal(msg)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
-	return string(jsonString)
+	return string(jsonBytes)
 }

--- a/protobuf.go
+++ b/protobuf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/bufbuild/protocompile"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -25,21 +26,30 @@ type ProtoFile struct {
 }
 
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
-	// Default import paths if none provided
+	// Default import paths if none provided.
+	// Include CWD (matches the original behavior without ImportPaths) and
+	// the proto file's directory (for imports relative to the same dir).
 	if len(importPaths) == 0 {
+		cwd, err := filepath.Abs(".")
+		if err != nil {
+			log.Fatalf("Failed to resolve current working directory: %v", err)
+		}
 		protoDir := filepath.Dir(protoFilePath)
 		absProtoDir, err := filepath.Abs(protoDir)
 		if err != nil {
-			absProtoDir = protoDir
+			log.Fatalf("Failed to resolve absolute path for proto directory %s: %v", protoDir, err)
 		}
-		importPaths = []string{absProtoDir}
+		importPaths = []string{cwd}
+		if absProtoDir != cwd {
+			importPaths = append(importPaths, absProtoDir)
+		}
 	} else {
 		// Convert all provided import paths to absolute paths
 		absImportPaths := make([]string, len(importPaths))
 		for i, path := range importPaths {
 			absPath, err := filepath.Abs(path)
 			if err != nil {
-				absPath = path
+				log.Fatalf("Failed to resolve absolute path for import path %s: %v", path, err)
 			}
 			absImportPaths[i] = absPath
 		}
@@ -52,13 +62,22 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
 		},
 	}
 
-	// Make proto file path relative to import path for protocompile
+	// Make proto file path relative to an import path for protocompile.
+	// protocompile joins each import path with the file path, so the file
+	// path must be relative to at least one of the import paths.
 	absProtoFile, err := filepath.Abs(protoFilePath)
-	if err == nil {
-		relPath, err := filepath.Rel(importPaths[0], absProtoFile)
-		if err == nil {
+	if err != nil {
+		log.Fatalf("Failed to resolve absolute path for proto file %s: %v", protoFilePath, err)
+	}
+	for _, ip := range importPaths {
+		relPath, err := filepath.Rel(ip, absProtoFile)
+		if err == nil && !strings.HasPrefix(relPath, "..") {
 			protoFilePath = relPath
+			break
 		}
+	}
+	if filepath.IsAbs(protoFilePath) {
+		log.Fatalf("Proto file %s is not under any of the provided import paths", protoFilePath)
 	}
 
 	files, err := compiler.Compile(context.Background(), protoFilePath)
@@ -74,11 +93,11 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
 
 	// Extract simple name from fully qualified name (e.g., "iot.test_messages.Ping" -> "Ping")
 	simpleName := lookupType
-	for i := len(lookupType) - 1; i >= 0; i-- {
-		if lookupType[i] == '.' {
-			simpleName = lookupType[i+1:]
-			break
-		}
+	if idx := strings.LastIndex(lookupType, "."); idx >= 0 {
+		simpleName = lookupType[idx+1:]
+	}
+	if simpleName == "" {
+		log.Fatalf("Invalid message type name: %s", lookupType)
 	}
 
 	messageDesc := files[0].Messages().ByName(protoreflect.Name(simpleName))

--- a/protobuf.go
+++ b/protobuf.go
@@ -27,7 +27,7 @@ type ProtoFile struct {
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
 	// Default import paths if none provided
     if len(importPaths) == 0 {
-        importPaths = []string{filepath.Dir(protoFile)}
+        importPaths = []string{filepath.Dir(protoFilePath)}
     }
 	
 	compiler := protocompile.Compiler{

--- a/protobuf.go
+++ b/protobuf.go
@@ -69,14 +69,7 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
     return ProtoFile{msgDesc}
 }
 
-func (p *ProtoFile) Encode(jsonString string) []byte {
-    // Show first 200 chars of JSON input
-    jsonPreview := jsonString
-    if len(jsonString) > 200 {
-        jsonPreview = jsonString[:200]
-    }
-    log.Printf("DEBUG Encode: input JSON length=%d, first chars=%s", len(jsonString), jsonPreview)
-    
+func (p *ProtoFile) Encode(jsonString string) string {
     msg := dynamicpb.NewMessage(p.messageDesc)
     err := protojson.Unmarshal([]byte(jsonString), msg)
     if err != nil {
@@ -84,27 +77,13 @@ func (p *ProtoFile) Encode(jsonString string) []byte {
         panic(err)
     }
     
-    // Count how many fields are set
-    fieldCount := 0
-    msg.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
-        log.Printf("DEBUG: Field %s (number %d) = %v", fd.Name(), fd.Number(), v)
-        fieldCount++
-        return true
-    })
-    log.Printf("DEBUG: After unmarshal, %d fields are set", fieldCount)
-    
     data, err := proto.Marshal(msg)
     if err != nil {
         panic(err)
     }
     
-    // Show first 20 bytes in hex
-    hexLen := 20
-    if len(data) < 20 {
-        hexLen = len(data)
-    }
-    log.Printf("DEBUG: Encoded to %d bytes, first %d hex: % x", len(data), hexLen, data[:hexLen])
-    return data
+    // Return as Go string (binary safe in Go, preserves all bytes 0-255)
+    return string(data)
 }
 
 func (p *ProtoFile) Decode(decodedBytes []byte) string {

--- a/protobuf.go
+++ b/protobuf.go
@@ -69,21 +69,25 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
     return ProtoFile{msgDesc}
 }
 
-func (p *ProtoFile) Encode(data string) []byte {
-	dynamicMessage := dynamicpb.NewMessage(p.messageDesc)
-
-	err := protojson.Unmarshal([]byte(data), dynamicMessage)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	encodedBytes, err := proto.Marshal(dynamicMessage)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return encodedBytes
+func (p *ProtoFile) Encode(jsonString string) []byte {
+    log.Printf("DEBUG Encode: input JSON length=%d, first 200 chars=%s", len(jsonString), jsonString[:min(200, len(jsonString))])
+    
+    msg := dynamicpb.NewMessage(p.messageDesc)
+    err := protojson.Unmarshal([]byte(jsonString), msg)
+    if err != nil {
+        log.Printf("ERROR: protojson.Unmarshal failed: %v", err)
+        panic(err)
+    }
+    
+    log.Printf("DEBUG: After unmarshal, message has %d fields set", len(msg.ProtoReflect().Descriptor().Fields()))
+    
+    data, err := proto.Marshal(msg)
+    if err != nil {
+        panic(err)
+    }
+    
+    log.Printf("DEBUG: Encoded to %d bytes, first 20 hex: % x", len(data), data[:min(20, len(data))])
+    return data
 }
 
 func (p *ProtoFile) Decode(decodedBytes []byte) string {

--- a/protobuf.go
+++ b/protobuf.go
@@ -23,9 +23,16 @@ type ProtoFile struct {
 	messageDesc protoreflect.MessageDescriptor
 }
 
-func (p *Protobuf) Load(protoFilePath, lookupType string) ProtoFile {
+func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
+	// Default import paths if none provided
+    if len(importPaths) == 0 {
+        importPaths = []string{".", "proto", "k6-scripts/proto"}
+    }
+	
 	compiler := protocompile.Compiler{
-		Resolver: &protocompile.SourceResolver{},
+		Resolver: &protocompile.SourceResolver{
+			ImportPaths: importPaths,
+		},
 	}
 
 	files, err := compiler.Compile(context.Background(), protoFilePath)

--- a/protobuf.go
+++ b/protobuf.go
@@ -32,17 +32,27 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
         // Convert to absolute path
         absProtoDir, err := filepath.Abs(protoDir)
         if err != nil {
-            // Fallback to relative path if Abs fails
+            log.Printf("Failed to get absolute path for %s: %v", protoDir, err)
             absProtoDir = protoDir
         }
         
+        log.Printf("DEBUG: protoFilePath=%s, protoDir=%s, absProtoDir=%s", protoFilePath, protoDir, absProtoDir)
         importPaths = []string{absProtoDir}
     }
+    
+    log.Printf("DEBUG: Using ImportPaths: %v", importPaths)
     
     compiler := protocompile.Compiler{
         Resolver: &protocompile.SourceResolver{
             ImportPaths: importPaths,
         },
+    }
+    
+    // Also try resolving protoFilePath to absolute
+    absProtoFile, err := filepath.Abs(protoFilePath)
+    if err == nil {
+        log.Printf("DEBUG: Resolved proto file to: %s", absProtoFile)
+        protoFilePath = absProtoFile
     }
 
 	files, err := compiler.Compile(context.Background(), protoFilePath)

--- a/protobuf.go
+++ b/protobuf.go
@@ -70,7 +70,12 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
 }
 
 func (p *ProtoFile) Encode(jsonString string) []byte {
-    log.Printf("DEBUG Encode: input JSON length=%d, first 200 chars=%s", len(jsonString), jsonString[:min(200, len(jsonString))])
+    // Show first 200 chars of JSON input
+    jsonPreview := jsonString
+    if len(jsonString) > 200 {
+        jsonPreview = jsonString[:200]
+    }
+    log.Printf("DEBUG Encode: input JSON length=%d, first chars=%s", len(jsonString), jsonPreview)
     
     msg := dynamicpb.NewMessage(p.messageDesc)
     err := protojson.Unmarshal([]byte(jsonString), msg)
@@ -79,14 +84,26 @@ func (p *ProtoFile) Encode(jsonString string) []byte {
         panic(err)
     }
     
-    log.Printf("DEBUG: After unmarshal, message has %d fields set", len(msg.ProtoReflect().Descriptor().Fields()))
+    // Count how many fields are set
+    fieldCount := 0
+    msg.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+        log.Printf("DEBUG: Field %s (number %d) = %v", fd.Name(), fd.Number(), v)
+        fieldCount++
+        return true
+    })
+    log.Printf("DEBUG: After unmarshal, %d fields are set", fieldCount)
     
     data, err := proto.Marshal(msg)
     if err != nil {
         panic(err)
     }
     
-    log.Printf("DEBUG: Encoded to %d bytes, first 20 hex: % x", len(data), data[:min(20, len(data))])
+    // Show first 20 bytes in hex
+    hexLen := 20
+    if len(data) < 20 {
+        hexLen = len(data)
+    }
+    log.Printf("DEBUG: Encoded to %d bytes, first %d hex: % x", len(data), hexLen, data[:hexLen])
     return data
 }
 

--- a/protobuf.go
+++ b/protobuf.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/bufbuild/protocompile"
-	"go.k6.io/k6/js/modules"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"go.k6.io/k6/js/modules"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
@@ -23,7 +24,6 @@ type ProtoFile struct {
 	messageDesc protoreflect.MessageDescriptor
 }
 
-// Load compiles a proto file and returns a ProtoFile for encoding/decoding messages
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
 	// Default import paths if none provided
 	if len(importPaths) == 0 {
@@ -54,11 +54,14 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if files == nil || len(files) == 0 {
-		log.Fatal("No files were compiled")
+	if files == nil {
+		log.Fatal("No files were passed as arguments")
+	}
+	if len(files) == 0 {
+		log.Fatal("Zero files were parsed")
 	}
 
-	// Extract simple name from fully qualified name (e.g., "infra.iot_comms_poc.Ping" -> "Ping")
+	// Extract simple name from fully qualified name (e.g., "iot.test_messages.Ping" -> "Ping")
 	simpleName := lookupType
 	for i := len(lookupType) - 1; i >= 0; i-- {
 		if lookupType[i] == '.' {
@@ -67,47 +70,48 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
 		}
 	}
 
-	msgDesc := files[0].Messages().ByName(protoreflect.Name(simpleName))
-	if msgDesc == nil {
+	messageDesc := files[0].Messages().ByName(protoreflect.Name(simpleName))
+	if messageDesc == nil {
 		log.Fatalf("Message type %s not found", lookupType)
 	}
 
-	return ProtoFile{msgDesc}
+	return ProtoFile{messageDesc}
 }
 
-// Encode converts JSON string to protobuf binary format
-// Returns as Go string (binary safe) for compatibility with xk6-nats
-func (p *ProtoFile) Encode(jsonString string) string {
-	msg := dynamicpb.NewMessage(p.messageDesc)
-	
-	err := protojson.Unmarshal([]byte(jsonString), msg)
+func (p *ProtoFile) Encode(data string) string {
+	dynamicMessage := dynamicpb.NewMessage(p.messageDesc)
+
+	err := protojson.Unmarshal([]byte(data), dynamicMessage)
+
 	if err != nil {
-		log.Printf("ERROR: protojson.Unmarshal failed: %v", err)
-		panic(err)
+		log.Fatal(err)
 	}
 
-	data, err := proto.Marshal(msg)
+	encodedBytes, err := proto.Marshal(dynamicMessage)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
-	// Return as string to avoid UTF-8 corruption when passing to xk6-nats
-	return string(data)
+	return string(encodedBytes)
 }
 
-// Decode converts protobuf binary format to JSON string
 func (p *ProtoFile) Decode(decodedBytes []byte) string {
-	msg := dynamicpb.NewMessage(p.messageDesc)
-	
-	err := proto.Unmarshal(decodedBytes, msg)
+
+	decodedMessage := dynamicpb.NewMessage(p.messageDesc)
+
+	err := proto.Unmarshal(decodedBytes, decodedMessage)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
-	jsonBytes, err := protojson.Marshal(msg)
-	if err != nil {
-		panic(err)
+	marshalOptions := protojson.MarshalOptions{
+		UseProtoNames: true,
 	}
 
-	return string(jsonBytes)
+	jsonString, err := marshalOptions.Marshal(decodedMessage)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return string(jsonString)
 }

--- a/protobuf.go
+++ b/protobuf.go
@@ -27,14 +27,23 @@ type ProtoFile struct {
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
 	// Default import paths if none provided
     if len(importPaths) == 0 {
-        importPaths = []string{filepath.Dir(protoFilePath)}
+        protoDir := filepath.Dir(protoFilePath)
+        
+        // Convert to absolute path
+        absProtoDir, err := filepath.Abs(protoDir)
+        if err != nil {
+            // Fallback to relative path if Abs fails
+            absProtoDir = protoDir
+        }
+        
+        importPaths = []string{absProtoDir}
     }
-	
-	compiler := protocompile.Compiler{
-		Resolver: &protocompile.SourceResolver{
-			ImportPaths: importPaths,
-		},
-	}
+    
+    compiler := protocompile.Compiler{
+        Resolver: &protocompile.SourceResolver{
+            ImportPaths: importPaths,
+        },
+    }
 
 	files, err := compiler.Compile(context.Background(), protoFilePath)
 	if err != nil {

--- a/protobuf.go
+++ b/protobuf.go
@@ -25,22 +25,12 @@ type ProtoFile struct {
 }
 
 func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string) ProtoFile {
-	// Default import paths if none provided
+    // Default import paths if none provided
     if len(importPaths) == 0 {
         protoDir := filepath.Dir(protoFilePath)
-        
-        // Convert to absolute path
-        absProtoDir, err := filepath.Abs(protoDir)
-        if err != nil {
-            log.Printf("Failed to get absolute path for %s: %v", protoDir, err)
-            absProtoDir = protoDir
-        }
-        
-        log.Printf("DEBUG: protoFilePath=%s, protoDir=%s, absProtoDir=%s", protoFilePath, protoDir, absProtoDir)
+        absProtoDir, _ := filepath.Abs(protoDir)
         importPaths = []string{absProtoDir}
     }
-    
-    log.Printf("DEBUG: Using ImportPaths: %v", importPaths)
     
     compiler := protocompile.Compiler{
         Resolver: &protocompile.SourceResolver{
@@ -48,30 +38,30 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
         },
     }
     
-    // Make proto file path relative to the first import path
-    absProtoFile, err := filepath.Abs(protoFilePath)
-    if err == nil {
-        relPath, err := filepath.Rel(importPaths[0], absProtoFile)
-        if err == nil {
-            log.Printf("DEBUG: Using relative proto path: %s", relPath)
-            protoFilePath = relPath
-        } else {
-            log.Printf("DEBUG: Could not make relative path, using: %s", protoFilePath)
-        }
+    // Make proto file path relative to import path for protocompile
+    absProtoFile, _ := filepath.Abs(protoFilePath)
+    relPath, _ := filepath.Rel(importPaths[0], absProtoFile)
+
+    files, err := compiler.Compile(context.Background(), relPath)
+    if err != nil {
+        log.Fatal(err)
+    }
+    if files == nil || len(files.Files) == 0 {
+        log.Fatal("No files were compiled")
     }
 
-	files, err := compiler.Compile(context.Background(), protoFilePath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if files == nil {
-		log.Fatal("No files were passed as arguments")
-	}
-	if len(files) == 0 {
-		log.Fatal("Zero files were parsed")
-	}
+    // Use fully qualified name to find message
+    desc := files.FindDescriptorByName(protoreflect.FullName(lookupType))
+    if desc == nil {
+        log.Fatalf("Message type %s not found", lookupType)
+    }
+    
+    msgDesc, ok := desc.(protoreflect.MessageDescriptor)
+    if !ok {
+        log.Fatalf("%s is not a message type", lookupType)
+    }
 
-	return ProtoFile{files[0].Messages().ByName(protoreflect.Name(lookupType))}
+    return ProtoFile{msgDesc}
 }
 
 func (p *ProtoFile) Encode(data string) []byte {

--- a/protobuf.go
+++ b/protobuf.go
@@ -46,19 +46,24 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
     if err != nil {
         log.Fatal(err)
     }
-    if files == nil || len(files.Files) == 0 {
+    if files == nil || len(files) == 0 {
         log.Fatal("No files were compiled")
     }
 
-    // Use fully qualified name to find message
-    desc := files.FindDescriptorByName(protoreflect.FullName(lookupType))
-    if desc == nil {
-        log.Fatalf("Message type %s not found", lookupType)
+    // Extract simple name from fully qualified name (e.g., "infra.iot_comms_poc.Ping" -> "Ping")
+    simpleName := lookupType
+    if lastDot := len(lookupType) - 1; lastDot >= 0 {
+        for i := lastDot; i >= 0; i-- {
+            if lookupType[i] == '.' {
+                simpleName = lookupType[i+1:]
+                break
+            }
+        }
     }
-    
-    msgDesc, ok := desc.(protoreflect.MessageDescriptor)
-    if !ok {
-        log.Fatalf("%s is not a message type", lookupType)
+
+    msgDesc := files[0].Messages().ByName(protoreflect.Name(simpleName))
+    if msgDesc == nil {
+        log.Fatalf("Message type %s not found", lookupType)
     }
 
     return ProtoFile{msgDesc}

--- a/protobuf.go
+++ b/protobuf.go
@@ -48,11 +48,16 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
         },
     }
     
-    // Also try resolving protoFilePath to absolute
+    // Make proto file path relative to the first import path
     absProtoFile, err := filepath.Abs(protoFilePath)
     if err == nil {
-        log.Printf("DEBUG: Resolved proto file to: %s", absProtoFile)
-        protoFilePath = absProtoFile
+        relPath, err := filepath.Rel(importPaths[0], absProtoFile)
+        if err == nil {
+            log.Printf("DEBUG: Using relative proto path: %s", relPath)
+            protoFilePath = relPath
+        } else {
+            log.Printf("DEBUG: Could not make relative path, using: %s", protoFilePath)
+        }
     }
 
 	files, err := compiler.Compile(context.Background(), protoFilePath)

--- a/protobuf.go
+++ b/protobuf.go
@@ -33,6 +33,17 @@ func (p *Protobuf) Load(protoFilePath, lookupType string, importPaths ...string)
 			absProtoDir = protoDir
 		}
 		importPaths = []string{absProtoDir}
+	} else {
+		// Convert all provided import paths to absolute paths
+		absImportPaths := make([]string, len(importPaths))
+		for i, path := range importPaths {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				absPath = path
+			}
+			absImportPaths[i] = absPath
+		}
+		importPaths = absImportPaths
 	}
 
 	compiler := protocompile.Compiler{

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -1,0 +1,80 @@
+package protobuf
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSimpleProto(t *testing.T) {
+	p := &Protobuf{}
+	pf := p.Load("example/v1/country.proto", "Country")
+	if pf.messageDesc == nil {
+		t.Fatal("expected messageDesc to be non-nil")
+	}
+}
+
+func TestLoadProtoWithImport(t *testing.T) {
+	p := &Protobuf{}
+	pf := p.Load("example/v1/example.proto", "CountryList")
+	if pf.messageDesc == nil {
+		t.Fatal("expected messageDesc to be non-nil")
+	}
+}
+
+func TestLoadWithAbsolutePath(t *testing.T) {
+	p := &Protobuf{}
+	absPath, err := filepath.Abs("example/v1/country.proto")
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+	pf := p.Load(absPath, "Country")
+	if pf.messageDesc == nil {
+		t.Fatal("expected messageDesc to be non-nil")
+	}
+}
+
+func TestLoadWithExplicitImportPaths(t *testing.T) {
+	p := &Protobuf{}
+	// Load using just the filename, relying on the explicit import path
+	// to resolve it. Without "example/v1", protocompile can't find "country.proto".
+	pf := p.Load("country.proto", "Country", "example/v1")
+	if pf.messageDesc == nil {
+		t.Fatal("expected messageDesc to be non-nil")
+	}
+}
+
+func TestLoadWithFQN(t *testing.T) {
+	p := &Protobuf{}
+	pf := p.Load("example/v1/country.proto", "example.v1.Country")
+	if pf.messageDesc == nil {
+		t.Fatal("expected messageDesc to be non-nil")
+	}
+}
+
+func TestEncodeAndDecode(t *testing.T) {
+	p := &Protobuf{}
+	pf := p.Load("example/v1/country.proto", "Country")
+
+	input := `{"name":"Poland","area":312696,"population":38000000,"capital":"Warsaw"}`
+	encoded := pf.Encode(input)
+	if len(encoded) == 0 {
+		t.Fatal("encoded output is empty")
+	}
+
+	decoded := pf.Decode([]byte(encoded))
+	// Verify the decoded JSON contains the same data
+	var original, result map[string]interface{}
+	if err := json.Unmarshal([]byte(input), &original); err != nil {
+		t.Fatalf("failed to parse input JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(decoded), &result); err != nil {
+		t.Fatalf("failed to parse decoded JSON: %v", err)
+	}
+	if result["name"] != original["name"] {
+		t.Errorf("name mismatch: got %v, want %v", result["name"], original["name"])
+	}
+	if result["capital"] != original["capital"] {
+		t.Errorf("capital mismatch: got %v, want %v", result["capital"], original["capital"])
+	}
+}


### PR DESCRIPTION
### Summary

Adds support for proto file imports and fixes binary data handling to enable real-world usage in k6 load testing. These changes allow xk6-protobuf to work with complex proto definitions that use Google Well-Known Types and nested imports, while ensuring encoded messages remain binary-safe when passed through JavaScript.

### Problem

When using xk6-protobuf in k6 load tests with realistic proto definitions, we encountered three blocking issues:

#### 1. Import Resolution Failure
Proto files using imports failed to compile:
```
open google/protobuf/duration.proto: no such file or directory
```

Example proto that would fail:
```protobuf
syntax = "proto3";
package iot.test_messages;

import "google/protobuf/timestamp.proto";
import "google/protobuf/duration.proto";

message Ping {
  int64 id = 1;
  google.protobuf.Timestamp sent_time = 2;
}
```

**Root cause**: The `SourceResolver` had no `ImportPaths` configured, so `protocompile` couldn't resolve any imports.

#### 2. Path Concatenation Issue
After adding ImportPaths, loading still failed with doubled paths:
```
open /path/to/proto//path/to/proto/messages.proto: no such file or directory
```

**Root cause**: `protocompile` treats the proto file path as relative to ImportPaths and concatenates them. We needed to convert absolute paths to relative paths.

#### 3. Binary Data Corruption in JavaScript
Encoded protobuf messages were corrupted when used in k6 scripts. Comparing hex dumps of the same message showed UTF-8 double-encoding:
```
Expected: 0a 0f 74 65 73 74 2d 64 65 76 69 63 65  (field 1, string)
Actual:   c2 9b c3 b3 c2 bf c2 9b c3 87...         (UTF-8 encoded bytes)
```

**Root cause**: When `Encode()` returned `[]byte`, k6's JavaScript environment converted it using `String.fromCharCode()`. This causes bytes > 127 to become multi-byte UTF-8 sequences:
- Byte `0x9b` → Unicode U+009B → UTF-8 `c2 9b` (2 bytes)
- Byte `0xb3` → Unicode U+00B3 → UTF-8 `c2 b3` (2 bytes)

This corrupts the protobuf wire format, making messages undecodable by downstream services.

### Solution

#### 1. ImportPaths Support
```go
compiler := protocompile.Compiler{
    Resolver: &protocompile.SourceResolver{
        ImportPaths: importPaths,  // Enable proto import resolution
    },
}
```

Defaults to the proto file's directory if no import paths provided, enabling automatic resolution of relative imports.

#### 2. Relative Path Conversion
```go
absProtoFile, _ := filepath.Abs(protoFilePath)
relPath, _ := filepath.Rel(importPaths[0], absProtoFile)
protoFilePath = relPath  // Use relative path for compilation
```

Converts absolute paths to paths relative to the import directory, preventing path concatenation issues.

#### 3. Binary-Safe String Return
```go
func (p *ProtoFile) Encode(jsonString string) string {
    // ... marshal to []byte ...
    return string(data)  // Go string preserves all bytes 0-255
}
```

Changed return type from `[]byte` to `string`. In Go, strings are binary-safe and preserve all byte values 0-255. When k6 receives this string from Go, it preserves the raw bytes without UTF-8 re-encoding, allowing binary data to be used correctly (e.g., published to message brokers, written to files, etc.).

#### 4. Fully Qualified Name Support
Added logic to extract simple names from fully qualified message names (e.g., `iot.test_messages.Ping` → `Ping`) for compatibility with `ByName()` lookups.

### Testing

Validated with a k6 load test that:
- ✅ Loads proto files with Google WKT imports (`google.protobuf.Timestamp`, `google.protobuf.Duration`)
- ✅ Loads proto files with nested package imports
- ✅ Encodes messages that decode correctly in downstream Go services (wire-compatible)
- ✅ Binary data passes through JavaScript without corruption

**Before**: Services reported `proto: cannot parse invalid wire-format data`  
**After**: Messages decode successfully with all fields intact

### Use Case

This enables using xk6-protobuf for realistic load testing scenarios where:
- Proto definitions use imports (standard practice in production)
- Encoded messages need to be sent over the network or processed by other k6 extensions
- Downstream services need to decode the messages (requires wire-compatible protobuf)

### Backward Compatibility

✅ **Fully backward compatible**
- `importPaths` parameter is optional (defaults to proto file directory)
- Return type change from `[]byte` to `string` is transparent to JavaScript consumers
- Existing code without imports continues to work